### PR TITLE
Remove unused imports and ensure utils package

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -15,10 +15,7 @@ from PySide6.QtCore import Qt, QSize, QPoint
 from PySide6.QtGui import QPainter, QPixmap, QKeySequence, QShortcut, QImage
 
 import config
-from cache import image_cache
-from optimizer import ImageOptimizer
 from widgets.collage import CollageWidget
-from workers import TaskQueue, Worker
 from managers.autosave import AutosaveManager
 from managers.performance import PerformanceMonitor
 from managers.recovery import ErrorRecoveryManager

--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -5,7 +5,7 @@ Provides functions to scale images for display and extract metadata safely.
 """
 
 from typing import Dict
-from PySide6.QtCore import Qt, QSize, QFileInfo, QDateTime
+from PySide6.QtCore import Qt, QSize, QFileInfo
 from PySide6.QtGui import QImage, QImageReader
 
 import config

--- a/src/widgets/cell.py
+++ b/src/widgets/cell.py
@@ -12,7 +12,7 @@ from PySide6.QtCore import (
     Qt, QMimeData, QByteArray, QDataStream, QIODevice, QRect, QSize, QPoint
 )
 from PySide6.QtGui import (
-    QPainter, QPixmap, QImageReader, QImage, QColor, QDrag
+    QPainter, QPixmap, QImageReader, QColor, QDrag
 )
 
 import config

--- a/src/workers.py
+++ b/src/workers.py
@@ -10,10 +10,8 @@ from PySide6.QtCore import QRunnable, QThreadPool, QObject, Signal, QSize
 from PySide6.QtWidgets import QProgressDialog, QMessageBox
 from PySide6.QtGui import QImageReader, QPixmap
 
-import config
 from cache import image_cache
 from optimizer import ImageOptimizer
-from widgets.cell import CollageCell
 
 
 class WorkerSignals(QObject):

--- a/tests/test_image_processor.py
+++ b/tests/test_image_processor.py
@@ -2,7 +2,6 @@ import os
 import sys
 from pathlib import Path
 
-import pytest
 from PIL import Image
 
 # Ensure project root on path

--- a/tests/test_utils_imports.py
+++ b/tests/test_utils_imports.py
@@ -1,0 +1,5 @@
+def test_utils_package_imports():
+    import utils
+    assert hasattr(utils, "collage_layouts")
+    assert hasattr(utils, "image_processor")
+

--- a/ui/collage_canvas.py
+++ b/ui/collage_canvas.py
@@ -1,13 +1,13 @@
 import logging
-from typing import List, Optional, Tuple, Dict
+from typing import List, Optional, Dict
 from PyQt5.QtWidgets import (
-    QWidget, QGridLayout, QVBoxLayout, QMessageBox, 
+    QWidget, QGridLayout, QMessageBox,
     QSizePolicy
 )
 from PyQt5.QtCore import Qt, QSize, pyqtSignal, QTimer
 from PyQt5.QtGui import QPixmap, QPainter, QColor, QImage
 from utils.collage_layouts import CollageLayouts
-from utils.image_processor import ImageProcessor, ImageProcessingError
+from utils.image_processor import ImageProcessor
 from .image_label import ImageLabel
 
 class CollageCanvas(QWidget):

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1,11 +1,9 @@
 import logging
 from typing import Optional
 from PyQt5.QtWidgets import (
-    QMainWindow, QWidget, QVBoxLayout, QHBoxLayout, 
+    QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
     QPushButton, QComboBox, QFileDialog, QMessageBox
 )
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon
 from .collage_canvas import CollageCanvas
 from utils.collage_layouts import CollageLayouts
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,6 @@
+"""Utility package for collage maker."""
+
+from . import collage_layouts, image_processor
+
+__all__ = ["collage_layouts", "image_processor"]
+


### PR DESCRIPTION
## Summary
- prune unused imports across core modules to satisfy lint checks
- add explicit `utils` package initializer and regression test for exposed modules
- streamline UI canvas and main window imports

## Testing
- `flake8 --select=E9,F63,F7,F82,F401,F821`
- `python -m py_compile $(git ls-files '*.py')`
- `mypy --ignore-missing-imports utils tests/test_utils_imports.py tests/test_image_processor.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcbffb98f483288a8d49b0fcc55ae8