### PR TITLE
Fix resize logic in ImageProcessor and expand tests

### DIFF
--- a/tests/test_image_processor.py
+++ b/tests/test_image_processor.py
@@ -10,8 +10,8 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from utils.image_processor import ImageProcessor
 
 
-def create_temp_image(tmp_path: Path) -> Path:
-    img = Image.new("RGB", (10, 10), color="red")
+def create_temp_image(tmp_path: Path, size=(10, 10)) -> Path:
+    img = Image.new("RGB", size, color="red")
     path = tmp_path / "img.png"
     img.save(path)
     return path
@@ -26,3 +26,19 @@ def test_processing_uses_cache(tmp_path):
     second = processor.process_image(image_path, ops)
 
     assert first is second  # cached object returned
+
+
+def test_resize_without_aspect(tmp_path):
+    image_path = create_temp_image(tmp_path, size=(10, 20))
+    ops = [{"type": "resize", "params": {"size": (4, 8), "keep_aspect": False}}]
+    processor = ImageProcessor()
+    result = processor.process_image(image_path, ops)
+    assert result.size == (4, 8)
+
+
+def test_resize_preserves_aspect_when_requested(tmp_path):
+    image_path = create_temp_image(tmp_path, size=(10, 20))
+    ops = [{"type": "resize", "params": {"size": (10, 10), "keep_aspect": True}}]
+    processor = ImageProcessor()
+    result = processor.process_image(image_path, ops)
+    assert result.size == (5, 10)

--- a/utils/image_processor.py
+++ b/utils/image_processor.py
@@ -157,8 +157,10 @@ class ImageProcessor:
     def _resize_image(image: Image.Image, size: Tuple[int, int], keep_aspect: bool = True) -> Image.Image:
         """Resize an image."""
         if keep_aspect:
-            return image.resize(size, Image.Resampling.LANCZOS)
-        return image.thumbnail(size, Image.Resampling.LANCZOS)
+            resized = image.copy()
+            resized.thumbnail(size, Image.Resampling.LANCZOS)
+            return resized
+        return image.resize(size, Image.Resampling.LANCZOS)
         
     @staticmethod
     def _rotate_image(image: Image.Image, angle: float, expand: bool = True) -> Image.Image:


### PR DESCRIPTION
## Summary
- ensure ImageProcessor.resize uses thumbnail only for aspect-preserving mode and returns resized image for non-aspect mode
- add tests for resize without aspect ratio and for aspect-preserving resize

## Testing
- `pytest tests/test_image_processor.py::test_resize_without_aspect -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bcc1d9f6448328a734f54bcf8b596e