### PR TITLE
Optimize layout lookup with caching

### DIFF
--- a/tests/performance/test_collage_layouts_perf.py
+++ b/tests/performance/test_collage_layouts_perf.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import timeit
+
+# Ensure project root on path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from utils.collage_layouts import CollageLayouts
+
+
+def test_get_layouts_by_tag_perf():
+    CollageLayouts._invalidate_caches()
+    loops = 10000
+    duration = timeit.timeit(
+        "CollageLayouts.get_layouts_by_tag('grid')",
+        globals={'CollageLayouts': CollageLayouts},
+        number=loops,
+    )
+    print(f"get_layouts_by_tag {duration/loops*1e6:.3f} us per call over {loops} loops")
+    assert duration > 0
+
+
+def test_get_layout_names_perf():
+    CollageLayouts._invalidate_caches()
+    loops = 10000
+    duration = timeit.timeit(
+        "CollageLayouts.get_layout_names()",
+        globals={'CollageLayouts': CollageLayouts},
+        number=loops,
+    )
+    print(f"get_layout_names {duration/loops*1e6:.3f} us per call over {loops} loops")
+    assert duration > 0


### PR DESCRIPTION
## Summary
- cache layout names and tag lookups to avoid repeated scans
- add cache invalidation on layout changes
- add simple benchmarks for layout lookups

## Testing
- `pytest`
- `pytest -s tests/performance/test_collage_layouts_perf.py`
- `python -m timeit -n 10000 -s "from utils.collage_layouts import CollageLayouts" "CollageLayouts.get_layouts_by_tag('grid')"`
- `python -m timeit -n 10000 -s "from utils.collage_layouts import CollageLayouts" "CollageLayouts.get_layout_names()"`


------
https://chatgpt.com/codex/tasks/task_e_68bcc341b5708328918fc505f6e3db37