### PR TITLE
feat: harden autosave with structured logging and metrics

### DIFF
--- a/src/managers/autosave.py
+++ b/src/managers/autosave.py
@@ -1,50 +1,109 @@
 # managers/autosave.py
+"""Autosave manager with structured logging and metrics.
+
+This module now exposes :class:`AutosaveManager` which periodically saves
+collage state to JSON.  Errors surface as :class:`AutosaveError` with rich
+context and retries with exponential backoff.  All operations emit
+structured logs including a correlation identifier (``cid``) so that issues
+can be traced across systems.  Basic metrics are recorded via the
+``autosave_metrics`` instance which tracks success and failure counts as well
+as observed durations.
 """
-AutosaveManager: periodically saves collage state to JSON and manages old file cleanup.
-"""
-import os
+
+from __future__ import annotations
+
 import glob
 import json
 import logging
+import os
+import time
+import uuid
+from collections import Counter
 from typing import Optional
 
-from PySide6.QtCore import QTimer, QDateTime
+from PySide6.QtCore import QDateTime, QTimer
 
-import config
+from .. import config
+
+
+class AutosaveError(RuntimeError):
+    """Raised when an autosave operation ultimately fails."""
+
+
+class _AutosaveMetrics:
+    """Simple in-memory metrics collector."""
+
+    def __init__(self) -> None:
+        self.counters: Counter[str] = Counter()
+        self.durations: list[float] = []
+
+    def record(self, name: str, duration: float | None = None) -> None:
+        self.counters[name] += 1
+        if duration is not None:
+            self.durations.append(duration)
+
+
+autosave_metrics = _AutosaveMetrics()
 
 
 class AutosaveManager:
     """Handles periodic autosaving of application state."""
-    def __init__(self, parent, save_callback: callable):
+
+    def __init__(self, parent, save_callback: callable, timer: Optional[QTimer] = None):
         self.parent = parent
         self.save_callback = save_callback
-        self.timer = QTimer(parent)
+        self.timer = timer or QTimer(parent)
         self.timer.timeout.connect(self.perform_autosave)
         self.timer.start(config.AUTOSAVE_INTERVAL_MS)
         self.path = config.AUTOSAVE_PATH
         os.makedirs(self.path, exist_ok=True)
 
     def perform_autosave(self) -> None:
-        try:
-            timestamp = QDateTime.currentDateTime().toString(config.AUTOSAVE_TIMESTAMP_FORMAT)
-            fname = f"collage_autosave_{timestamp}.json"
-            full = os.path.join(self.path, fname)
-            state = self.save_callback()
-            with open(full, 'w', encoding='utf-8') as f:
-                json.dump(state, f)
-            self._cleanup_old()
-            logging.info("Autosaved state to %s", full)
-        except Exception as e:
-            logging.error("Autosave failed: %s", e)
+        """Persist current state to disk with retries and structured logs."""
+        cid = uuid.uuid4().hex
+        log = logging.LoggerAdapter(logging.getLogger(__name__), {"cid": cid})
+        timestamp = QDateTime.currentDateTime().toString(config.AUTOSAVE_TIMESTAMP_FORMAT)
+        fname = f"collage_autosave_{timestamp}.json"
+        full = os.path.join(self.path, fname)
+        retries = 3
+        backoff = 0.1
+        start = time.perf_counter()
+        for attempt in range(1, retries + 1):
+            try:
+                state = self.save_callback()
+                with open(full, "w", encoding="utf-8") as f:
+                    json.dump(state, f)
+                self._cleanup_old(log)
+                duration = (time.perf_counter() - start) * 1000
+                autosave_metrics.record("success", duration)
+                log.info("autosave complete", extra={"path": full, "duration_ms": duration})
+                return
+            except Exception as exc:  # pragma: no cover - caught and reraised
+                log.warning(
+                    "autosave attempt failed",  # Runbook: check disk space, permissions
+                    extra={"attempt": attempt, "path": full, "error": str(exc)},
+                )
+                if attempt == retries:
+                    autosave_metrics.record("failure")
+                    log.error(
+                        "autosave failed after retries",  # Runbook: see storage troubleshooting
+                        extra={"path": full, "error": str(exc)},
+                    )
+                    raise AutosaveError(f"Failed to autosave to {full}") from exc
+                time.sleep(backoff)
+                backoff *= 2
 
-    def _cleanup_old(self) -> None:
+    def _cleanup_old(self, log: Optional[logging.LoggerAdapter] = None) -> None:
         pattern = os.path.join(self.path, "collage_autosave_*.json")
         files = sorted(glob.glob(pattern), key=os.path.getctime, reverse=True)
         for old in files[config.MAX_AUTOSAVE_FILES:]:
             try:
                 os.remove(old)
-            except Exception:
-                pass
+            except OSError as exc:
+                (log or logging.getLogger(__name__)).warning(
+                    "cleanup failed",  # Runbook: verify file permissions
+                    extra={"file": old, "error": str(exc)},
+                )
 
     def get_latest(self) -> Optional[str]:
         pattern = os.path.join(self.path, "collage_autosave_*.json")

--- a/tests/test_autosave_manager.py
+++ b/tests/test_autosave_manager.py
@@ -1,0 +1,83 @@
+import builtins
+import logging
+import os
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from src import config
+from src.managers.autosave import AutosaveError, AutosaveManager, autosave_metrics
+
+
+class DummyTimer:
+    """Stub QTimer used for testing."""
+
+    def __init__(self):
+        self.timeout = type("T", (), {"connect": lambda *a, **k: None})()
+
+    def start(self, *_):
+        pass
+
+
+def setup_manager(tmp_path):
+    autosave_metrics.counters.clear()
+    autosave_metrics.durations.clear()
+    manager = AutosaveManager(parent=None, save_callback=lambda: {"foo": "bar"}, timer=DummyTimer())
+    manager.path = str(tmp_path)
+    os.makedirs(manager.path, exist_ok=True)
+    return manager
+
+
+def test_autosave_retries_and_logs(tmp_path, caplog, monkeypatch):
+    manager = setup_manager(tmp_path)
+
+    orig_open = builtins.open
+    attempts = {"count": 0}
+
+    def fake_open(*args, **kwargs):
+        if attempts["count"] < 2:
+            attempts["count"] += 1
+            raise OSError("boom")
+        return orig_open(*args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+
+    caplog.set_level(logging.INFO)
+    manager.perform_autosave()
+
+    assert attempts["count"] == 2
+    assert autosave_metrics.counters["success"] == 1
+    assert any("cid" in r.__dict__ for r in caplog.records)
+
+
+def test_autosave_failure_raises(tmp_path, monkeypatch):
+    manager = setup_manager(tmp_path)
+
+    def always_fail(*_, **__):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(builtins, "open", always_fail)
+
+    with pytest.raises(AutosaveError):
+        manager.perform_autosave()
+
+    assert autosave_metrics.counters["failure"] == 1
+
+
+def test_cleanup_logs_warning(tmp_path, caplog, monkeypatch):
+    manager = setup_manager(tmp_path)
+    for i in range(config.MAX_AUTOSAVE_FILES + 1):
+        Path(manager.path, f"collage_autosave_{i}.json").write_text("{}")
+
+    def fail_remove(_):
+        raise OSError("nope")
+
+    monkeypatch.setattr(os, "remove", fail_remove)
+
+    caplog.set_level(logging.WARNING)
+    manager._cleanup_old()
+
+    assert any("cleanup failed" in r.message for r in caplog.records)
+


### PR DESCRIPTION
## Summary
- add AutosaveError, correlation IDs, retry/backoff and metrics
- warn and capture context when autosave cleanup fails
- cover autosave with retry and logging tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcd5f6f5688328b23bbc0e6b55c718