### PR TITLE
Remove deprecated imghdr usage in image validator

### DIFF
--- a/utils/image_processor.py
+++ b/utils/image_processor.py
@@ -2,8 +2,7 @@ from pathlib import Path
 from typing import Tuple, List, Dict, Any, Optional, Union
 from dataclasses import dataclass
 import logging
-import imghdr
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 import hashlib
 from concurrent.futures import ThreadPoolExecutor
 
@@ -65,17 +64,13 @@ class ImageProcessor:
                 
             if path.suffix.lower() not in ImageProcessor.VALID_EXTENSIONS:
                 return False
-                
-            # Verify file type
-            if not imghdr.what(str(path)):
-                return False
-                
+
             # Validate image data
             with Image.open(path) as img:
                 img.verify()
-                
+
             return True
-        except Exception as e:
+        except (UnidentifiedImageError, OSError) as e:
             logging.warning(f"Invalid image file {file_path}: {e}")
             return False
             


### PR DESCRIPTION
## Summary
- drop deprecated `imghdr` module
- rely on Pillow to verify image files

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcd7bc08f883289c0526442af14e5b